### PR TITLE
Restore Index Preview (1.6)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 
 # Color Chooser Field
 
-Version: 1.5    
+Version: 1.6    
 Maintainer: Deux Huit Huit (<https://deuxhuithuit.com>)    
 Original Author: Josh Nichols (mrblank@gmail.com)    
 Requirements: Symphony 2.4    

--- a/assets/farbtastic.css
+++ b/assets/farbtastic.css
@@ -19,3 +19,14 @@
 
 
 .field-colorchooser input {background: none;}
+
+.colorchooser-index-preview {
+	display: inline-block;
+	position: relative;
+	top: .3rem;
+	margin-top: -.1rem;
+	height: 1rem;
+	width: 1rem;
+	border: .1rem solid black;
+	cursor: default;
+}

--- a/assets/jquery.color-chooser.js
+++ b/assets/jquery.color-chooser.js
@@ -5,30 +5,25 @@
 	
 	$(document).ready(function() {
 		/*----Index page swatches----*/
-			// Find TDs that contain a '#'
-			$("tbody tr td:contains('#')").each(function() {
+		// Find TDs that contain a '#'
+		$("tbody tr td.field-colorchooser:contains('#')").each(function() {
 
-				var $td = $(this)
-				// Select the value of the TD
-				var td_data = $td.text()
-				// Strip out any extra spaces
-				td_data = jQuery.trim(td_data);
+			var $td = $(this)
+			// Select the value of the TD
+			var td_data = $td.text()
+			// Strip out any extra spaces
+			td_data = jQuery.trim(td_data);
 
-				// Validate hex length
-				if(td_data.length == 7 || td_data.length == 4){
-					// Add a SPAN for the color box
-					$td.prepend('<span>\&nbsp;</span>');	
-					// Add styles to the SPAN 
-					$td.children('span:first-child').css({
-						'background-color': td_data, 
-						'margin-right' : '5px',
-						'border' : 'solid 1px #eaeaea',
-						'padding' : '3px 8px'
-					});
+			// Validate hex length
+			if(td_data.length == 7 || td_data.length == 4){
+				// Remove readable hex-value
+				$td.html('');
+				// Add a span-element that's formatted as color preview
+				// Attach hex-value as title
+				$td.prepend('<span class="colorchooser-index-preview" title="'+td_data+'" style="background-color: '+td_data+';">\&nbsp;</span>');
+			}
 
-				}
-
-			});
+		});
 
 		/*----Color chooser field----*/
 		//If page has a color chooser field, call the Farbtastic function

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -1,18 +1,51 @@
 <?php
 
-	Class Extension_Color_Chooser_Field extends Extension
-	{
-		private static $assets_loaded = false;
+	Class Extension_Color_Chooser_Field extends Extension {
 
-		public function uninstall(){
-			try{
-				Symphony::Database()->query("DROP TABLE `tbl_fields_colorchooser`");
-			} catch( Exception $e ){
-			}
-
-			return true;
+		/*
+		 * Subscribe to delegates
+		 */
+		
+		public function getSubscribedDelegates() {
+			return array(
+				array(
+					'page'     => '/backend/',
+					'delegate' => 'InitaliseAdminPageHead',
+					'callback' => 'appendResources'
+				),
+			);
 		}
+		
+		/*********** DELEGATES ***********************/
 
+		/*
+		 * Appends resource (js/css) files references into the head, if needed
+		 * @param array $context
+		 */
+		
+		public function appendResources() {
+		
+			// store callback array locally
+			$c = Administration::instance()->getPageCallback();
+
+			// publish page, new or edit
+			if(in_array($c['context']['page'], array('index', 'new', 'edit'))){
+				
+				$page = Administration::instance()->Page;
+
+				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.farbtastic.js', 3001);
+				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.tools.min.js', 3002);
+				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.color-chooser.js', 3003);
+				$page->addStylesheetToHead(URL.'/extensions/color_chooser_field/assets/farbtastic.css', 'screen', 3004);
+
+				return;
+			}
+		}
+		
+		/*
+		 * Delegate fired when the extension is installed
+		 */
+		
 		public function install(){
 			return Symphony::Database()->query("CREATE TABLE `tbl_fields_colorchooser` (
 			  `id` int(11) unsigned NOT NULL auto_increment,
@@ -21,24 +54,18 @@
 			  UNIQUE KEY `field_id` (`field_id`)
 			) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
 		}
-
-		public static function appendAssets(){
-			if( self::$assets_loaded === false
-				&& class_exists('Administration')
-				&& Administration::instance() instanceof Administration
-				&& Administration::instance()->Page instanceof HTMLPage
-			){
-
-				self::$assets_loaded = true;
-
-				$page = Administration::instance()->Page;
-
-				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.farbtastic.js', 3001);
-				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.tools.min.js', 3002);
-				$page->addScriptToHead(URL.'/extensions/color_chooser_field/assets/jquery.color-chooser.js', 3003);
-				$page->addStylesheetToHead(URL.'/extensions/color_chooser_field/assets/farbtastic.css', 'screen', 3004);
-			}
-		}
+		
+		/*
+		 * Delegate fired when the extension is uninstalled
+		 * Cleans settings and Database
+		 */
+		
+		public function uninstall() {
+			try {
+				Symphony::Database()->query("DROP TABLE `tbl_fields_colorchooser`");
+			} catch( Exception $e ){}
+			return true;
+		}	
 	}
 
 ?>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -40,7 +40,12 @@
 	</media>
 
 	<releases>
-		<release version="1.5" date="2014-06-12" min="2.4" max="2.5.x">
+		<release version="1.6" date="2015-07-30" min="2.4" max="2.6.x">
+			* Adapted default layout to settings panel
+			* Restored color preview in entries table (index view)
+			* Marked as compatible with Symphony 2.6.X
+		</release>
+		<release version="1.5" date="2014-11-04" min="2.4" max="2.5.x">
 			* Update for Symphony 2.5
 			* Changed the xml output a bit, to be more consistent with other fields
 				- Do not output empty values (was outputing #)

--- a/fields/field.colorchooser.php
+++ b/fields/field.colorchooser.php
@@ -75,14 +75,18 @@
 		}
 
 		function displaySettingsPanel(&$wrapper, $errors = NULL){
+
 			parent::displaySettingsPanel($wrapper, $errors);
-			$this->appendRequiredCheckbox($wrapper);
-			$this->appendShowColumnCheckbox($wrapper);
+			
+			/* Option Group */
+			$optgroup = new XMLElement('div', NULL, array('class' => 'two columns'));
+			$this->appendRequiredCheckbox($optgroup);
+			$this->appendShowColumnCheckbox($optgroup);
+			$wrapper->appendChild($optgroup);
+			
 		}
 
 		function displayPublishPanel(&$wrapper, $data = NULL, $flagWithError = NULL, $fieldnamePrefix = NULL, $fieldnamePostfix = NULL){
-
-			Extension_Color_Chooser_Field::appendAssets();
 
 			$value = $data['value'];
 			$label = Widget::Label($this->get('label'));


### PR DESCRIPTION
I restored the color preview in the entries table that somehow
disappeared in the latest versions of this extension.

Made the preview a little smaller (size of a checkbox) than it used to
be - suits the ‘data’-oriented look of the table better in my eyes.

Did also switch to using delegates for the assets and tweaked the
settings panel a little bit.

I packed this up as version 1.6 that’s ready to release if you’re ok
with these changes.